### PR TITLE
Fix dbus_listener attribute name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ default['yum-updatesd']['do_download'] = False
 # Boolean option to automatically download dependencies of packages which need updating as well. Defaults to False. 
 default['yum-updatesd']['do_download_deps'] = False
 # Boolen option to listen via dbus to give out update information/check for new updates
-default['dbus_listener']['do_download_deps'] = False
+default['yum-updatesd']['dbus_listener'] = False
 
 #Mail Options
 # List of email addresses to send update notification to. Defaults to 'root@localhost'. 

--- a/attributes/main.rb
+++ b/attributes/main.rb
@@ -12,7 +12,7 @@ default['yum-updatesd']['do_download'] = false
 # Boolean option to automatically download dependencies of packages which need updating as well. Defaults to False. 
 default['yum-updatesd']['do_download_deps'] = false
 # Boolen option to listen via dbus to give out update information/check for new updates
-default['dbus_listener']['do_download_deps'] = false
+default['yum-updatesd']['dbus_listener'] = false
 
 # Mail Options
 # List of email addresses to send update notification to. Defaults to 'root@localhost'. 

--- a/templates/default/yum-updatesd.conf.erb
+++ b/templates/default/yum-updatesd.conf.erb
@@ -6,7 +6,7 @@ updaterefresh = <%= node['yum-updatesd']['updaterefresh'] %>
 # how to send notifications (valid: dbus, email, syslog)
 emit_via = <%= node['yum-updatesd']['emit_via'] %>
 # should we listen via dbus to give out update information/check for new updates
-dbus_listener = <%= node['yum-updatesd']['do_download_deps'] %>
+dbus_listener = <%= node['yum-updatesd']['dbus_listener'] %>
 
 # automatically install updates
 do_update = <%= node['yum-updatesd']['do_update'] %>


### PR DESCRIPTION
While trying out your cookbook on my systems, I ran across errors in the dbus_listener attribute name in attributes/main.rb and templates/default/yum-updatesd.conf.erb. This PR includes fixes for both files (and README.md).
